### PR TITLE
update to node 12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
 error @elastic/elasticsearch@7.14.0: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.24.1"

### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->



### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
